### PR TITLE
alleviate mps device memory leakage issue

### DIFF
--- a/cli_demo.py
+++ b/cli_demo.py
@@ -57,12 +57,16 @@ def main(stream=True):
                 for response in model.chat(tokenizer, messages, stream=True):
                     print(response[position:], end='', flush=True)
                     position = len(response)
+                    if torch.backends.mps.is_available():
+                        torch.mps.empty_cache()
             except KeyboardInterrupt:
                 pass
             print()
         else:
             response = model.chat(tokenizer, messages)
             print(response)
+            if torch.backends.mps.is_available():
+                torch.mps.empty_cache()
         messages.append({"role": "assistant", "content": response})
 
     print(Style.RESET_ALL)

--- a/web_demo.py
+++ b/web_demo.py
@@ -60,6 +60,8 @@ def main():
             placeholder = st.empty()
             for response in model.chat(tokenizer, messages, stream=True):
                 placeholder.markdown(response)
+                if torch.backends.mps.is_available():
+                    torch.mps.empty_cache()
         messages.append({"role": "assistant", "content": response})
         print(json.dumps(messages, ensure_ascii=False), flush=True)
 


### PR DESCRIPTION
With current code, web_demo.py and cli_demo.py experiences serious memory issue. Initial memory usage is 25GB, if user ask a complex enough question, it will go up to more than 70GB, speed will reduce to unusable

With this PR, this issue could be highly alleviate, in several round of chat with  complex questions, memory usage will not go beyond 50GB, it is usable with 64GB memory config MacBook