### PR TITLE
Completions API in OpenAI format

### DIFF
--- a/openai_api.py
+++ b/openai_api.py
@@ -1,0 +1,121 @@
+import time
+import torch
+import uvicorn
+from pydantic import BaseModel, Field
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from contextlib import asynccontextmanager
+from typing import List, Literal, Optional, Union
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers.generation.utils import GenerationConfig
+
+
+class ModelCard(BaseModel):
+    id: str
+    object: str = "model"
+    created: int = Field(default_factory=lambda: int(time.time()))
+    owned_by: str = "owner"
+    root: Optional[str] = None
+    parent: Optional[str] = None
+    permission: Optional[list] = None
+
+
+class ModelList(BaseModel):
+    object: str = "list"
+    data: List[ModelCard] = []
+
+
+class ChatMessage(BaseModel):
+    role: Literal["user", "assistant", "system"]
+    content: str
+
+
+class DeltaMessage(BaseModel):
+    role: Optional[Literal["user", "assistant", "system"]] = None
+    content: Optional[str] = None
+
+
+class ChatCompletionRequest(BaseModel):
+    model: str
+    messages: List[ChatMessage]
+    temperature: Optional[float] = None
+    top_p: Optional[float] = None
+    max_length: Optional[int] = None
+    stream: Optional[bool] = False
+
+
+class ChatCompletionResponseChoice(BaseModel):
+    index: int
+    message: ChatMessage
+    finish_reason: Literal["stop", "length"]
+
+
+class ChatCompletionResponseStreamChoice(BaseModel):
+    index: int
+    delta: DeltaMessage
+    finish_reason: Optional[Literal["stop", "length"]]
+
+
+class ChatCompletionResponse(BaseModel):
+    model: str
+    object: Literal["chat.completion", "chat.completion.chunk"]
+    choices: List[Union[ChatCompletionResponseChoice, ChatCompletionResponseStreamChoice]]
+    created: Optional[int] = Field(default_factory=lambda: int(time.time()))
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):  # collects GPU memory
+    yield
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+        torch.cuda.ipc_collect()
+
+
+app = FastAPI(lifespan=lifespan)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/v1/models", response_model=ModelList)
+async def list_models():
+    global model_args
+    model_card = ModelCard(id="gpt-3.5-turbo")
+    return ModelList(data=[model_card])
+
+
+@app.post("/v1/chat/completions", response_model=ChatCompletionResponse)
+async def create_chat_completion(request: ChatCompletionRequest):
+    global model, tokenizer
+    msgs = [_chat_message_to_baichuan_message(m) for m in request.messages]
+    response = model.chat(tokenizer, msgs)
+    choice_data = ChatCompletionResponseChoice(
+        index=0,
+        message=ChatMessage(role="assistant", content=response),
+        finish_reason="stop"
+    )
+
+    return ChatCompletionResponse(model=request.model, choices=[choice_data], object="chat.completion")
+
+
+def _chat_message_to_baichuan_message(message: ChatMessage):
+    return {
+        "role": message.role if message.role == "assistant" else "user",  # "system" role is not supported by Baichuan
+        "content": message.content
+    }
+
+
+if __name__ == "__main__":
+    model_id = "baichuan-inc/Baichuan-13B-Chat"
+
+    model = AutoModelForCausalLM.from_pretrained(
+        model_id, torch_dtype=torch.float16, device_map="auto", trust_remote_code=True)
+    model.generation_config = GenerationConfig.from_pretrained(model_id)
+    tokenizer = AutoTokenizer.from_pretrained(model_id, use_fast=False, trust_remote_code=True)
+
+    uvicorn.run(app, host='0.0.0.0', port=8000, workers=1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 accelerate
 colorama
 cpm_kernels
+fastapi
 sentencepiece
 streamlit
 transformers_stream_generator
+unicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ colorama
 cpm_kernels
 fastapi
 sentencepiece
+sse_starlette
 streamlit
 transformers_stream_generator
 unicorn


### PR DESCRIPTION
This work is originally done by @hiyouga for [ChatGLM2-6B](https://github.com/THUDM/ChatGLM2-6B/pull/18).
I think it is also very useful for Baichuan models.

Both the normal chat and stream style chat are supportted.

Normal chat example code:
``` python
import openai

if __name__ == "__main__":
    openai.api_base = "http://localhost:8000/v1"
    openai.api_key = "none"

    resp = openai.ChatCompletion.create(
        model="baichuan-inc/Baichuan-13B-Chat",
        messages = [{ "role":"user", "content": "Which moutain is the second highest one in the world?" }]
    )
    print(resp.choices[0].message.content)
```

Stream style chat example code:
``` python
import openai

if __name__ == "__main__":
    openai.api_base = "http://localhost:8000/v1"
    openai.api_key = "none"

    for chunk in openai.ChatCompletion.create(
        model="baichuan-inc/Baichuan-13B-Chat",
        messages=[{"role": "user", "content": "Which moutain is the second highest one in the world?"}],
        stream=True
    ):
        if hasattr(chunk.choices[0].delta, "content"):
            print(chunk.choices[0].delta.content, end="", flush=True)
```