### PR TITLE
Add OpenCompass badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 <div align="center">
 
 [![license](https://img.shields.io/github/license/modelscope/modelscope.svg)](https://github.com/Baichuan-inc/baichuan-13B/blob/main/LICENSE)
+[![evaluation](https://img.shields.io/badge/OpenCompass-Support-royalblue.svg)](https://github.com/internLM/OpenCompass/)
 <h4 align="center">
     <p>
         <b>中文</b> |

--- a/README_EN.md
+++ b/README_EN.md
@@ -20,6 +20,8 @@
 <div align="center">
 
 [![license](https://img.shields.io/github/license/modelscope/modelscope.svg)](https://github.com/Baichuan-inc/baichuan-13B/blob/main/LICENSE)
+[![evaluation](https://img.shields.io/badge/OpenCompass-Support-royalblue.svg)](https://github.com/internLM/OpenCompass/)
+
 <h4 align="center">
     <p>
         <b>English</b> |


### PR DESCRIPTION
Hi team,

Thanks for using OpenCompass! We're thrilled to see more LLM teams adopting the toolkit to evaluate models systematically. We deeply appreciate your dedication to transparency and reproducibility in LLM evaluation. Here we are wondering if you would add a badge to readme, with which visitors can quickly identify and appreciate the rigorous evaluation standards your model has undergone.

BTW, as OpenCompass continues to evolve, we welcome any evaluation requests or ideas for future collaborations. Feel free to let us know if your team needs any assistance.